### PR TITLE
dont throw an exception for simulating a transaction if the stripe pa…

### DIFF
--- a/src/main/java/com/lightrail/model/stripe/CheckoutWithStripeAndLightrail.java
+++ b/src/main/java/com/lightrail/model/stripe/CheckoutWithStripeAndLightrail.java
@@ -56,12 +56,8 @@ public class CheckoutWithStripeAndLightrail {
     }
 
     public boolean needsCreditCardPayment() throws IOException, CurrencyMismatchException, AuthorizationException, InsufficientValueException, CouldNotFindObjectException, ThirdPartyException {
-        try {
-            StripeLightrailSplitTenderCharge.simulate(getChargeParams()).getStripeCharge();
-        } catch (BadParameterException e) {
-            return true;
-        }
-        return false;
+        return (StripeLightrailSplitTenderCharge.simulate(getChargeParams()).getStripeCharge() != null);
+
     }
 
     public SimulatedStripeLightrailSplitTenderCharge simulate() throws IOException, CurrencyMismatchException, InsufficientValueException, AuthorizationException, CouldNotFindObjectException, ThirdPartyException {
@@ -69,11 +65,8 @@ public class CheckoutWithStripeAndLightrail {
     }
 
     public StripeLightrailSplitTenderCharge checkout() throws IOException, AuthorizationException, ThirdPartyException, CurrencyMismatchException, CouldNotFindObjectException, InsufficientValueException {
-        StripeLightrailSplitTenderCharge simulatedTx = simulate();
-        if (simulatedTx instanceof SimulatedStripeLightrailSplitTenderCharge)
-            return ((SimulatedStripeLightrailSplitTenderCharge) simulatedTx).commit();
-        else
-            return simulatedTx;
+        SimulatedStripeLightrailSplitTenderCharge simulatedTx = simulate();
+        return simulatedTx.commit();
     }
 
     private Map<String, Object> getChargeParams() {

--- a/src/main/java/com/lightrail/model/stripe/StripeLightrailSplitTenderCharge.java
+++ b/src/main/java/com/lightrail/model/stripe/StripeLightrailSplitTenderCharge.java
@@ -35,7 +35,7 @@ public class StripeLightrailSplitTenderCharge {
     }
 
     public String getIdempotencyKey() {
-        return (lightrailCharge!= null) ? lightrailCharge.getIdempotencyKey() : null;
+        return (lightrailCharge != null) ? lightrailCharge.getIdempotencyKey() : null;
     }
 
     private static Map<String, Object> getStripeParams(int amount, Map<String, Object> chargeParams, String lightrailTxFullId) {
@@ -151,8 +151,7 @@ public class StripeLightrailSplitTenderCharge {
         }
         stripeShare = transactionAmount - lightrailShare;
         if (stripeShare != 0) {
-            getStripeParams(stripeShare, chargeParams, null);
-
+            //getStripeParams(stripeShare, chargeParams, null);
 
             stripeCharge = new Charge();
             stripeCharge.setCurrency(currency);
@@ -204,10 +203,10 @@ public class StripeLightrailSplitTenderCharge {
                     stripeCharge = Charge.create(getStripeParams(stripeShare, chargeParams, lightrailCharge.getFullId()), stripeRequestOptions);
                 } catch (Exception e) {
                     lightrailCharge.doVoid();
-                    if (e instanceof StripeException)
-                        throw new ThirdPartyException(e);
+                    if (e instanceof BadParameterException)
+                        throw (BadParameterException) e;
                     else
-                        throw new RuntimeException(e);
+                        throw new ThirdPartyException(e);
                 }
                 lightrailCapturedCharge = lightrailCharge.capture(getLightrailMetadata(transactionAmount, stripeCharge.getId()));
             }
@@ -215,7 +214,10 @@ public class StripeLightrailSplitTenderCharge {
             try {
                 stripeCharge = Charge.create(getStripeParams(stripeShare, chargeParams, null));
             } catch (Exception e) {
-                throw new ThirdPartyException(e);
+                if (e instanceof BadParameterException)
+                    throw (BadParameterException) e;
+                else
+                    throw new ThirdPartyException(e);
             }
         }
 

--- a/src/test/java/com/lightrail/model/stripe/CheckoutWithStripeAndLightrailTest.java
+++ b/src/test/java/com/lightrail/model/stripe/CheckoutWithStripeAndLightrailTest.java
@@ -157,9 +157,9 @@ public class CheckoutWithStripeAndLightrailTest {
             StripeLightrailSplitTenderCharge checkout = checkoutWithGiftCode.checkout();
         } catch (Exception e) {
             assertEquals(BadParameterException.class.getName(), e.getClass().getName());
+        } finally {
+            returnFundsToCode(originalGiftValue);
         }
-
-        returnFundsToCode(originalGiftValue);
     }
 
     @Test


### PR DESCRIPTION
…rameters are not given because we may want to check whether we need credit card information